### PR TITLE
[WIP] use null pattern and remove proxy deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "type": "library",
     "require": {
         "doctrine/dbal": "~2.5",
-        "doctrine/cache": "^1.4"
+        "doctrine/cache": "^1.4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -2,7 +2,6 @@
 
 namespace AlexDpy\Acl;
 
-use AlexDpy\Acl\Cache\PermissionBuffer;
 use AlexDpy\Acl\Cache\PermissionBufferInterface;
 use AlexDpy\Acl\Exception\PermissionNotFoundException;
 use AlexDpy\Acl\Mask\MaskBuilderInterface;
@@ -45,8 +44,8 @@ class Acl implements AclInterface
      */
     public function __construct(
         Connection $connection,
-        $maskBuilderClass = 'AlexDpy\Acl\Mask\BasicMaskBuilder',
-        CacheProvider $cacheProvider = null
+        PermissionBufferInterface $permissionBuffer,
+        $maskBuilderClass = 'AlexDpy\Acl\Mask\BasicMaskBuilder'
     ) {
         if (!class_exists($maskBuilderClass)) {
             throw new \InvalidArgumentException(sprintf('Class "%s" does not exist', $maskBuilderClass));
@@ -59,9 +58,6 @@ class Acl implements AclInterface
         }
 
         $this->connection = $connection;
-
-        $permissionBuffer = new PermissionBuffer($cacheProvider);
-
         $this->permissionBuffer = $permissionBuffer;
     }
 

--- a/tests/AbstractAclTest.php
+++ b/tests/AbstractAclTest.php
@@ -4,6 +4,7 @@ namespace Tests\AlexDpy\Acl;
 
 use AlexDpy\Acl\Acl;
 use AlexDpy\Acl\AclInterface;
+use AlexDpy\Acl\Cache\PermissionBuffer;
 use AlexDpy\Acl\Schema\AclSchema;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
@@ -49,6 +50,6 @@ abstract class AbstractAclTest extends \PHPUnit_Framework_TestCase
             });
 
         $this->connection = $connection;
-        $this->acl = new Acl($connection);
+        $this->acl = new Acl($connection, new PermissionBuffer());
     }
 }

--- a/tests/Cache/PermissionBufferTest.php
+++ b/tests/Cache/PermissionBufferTest.php
@@ -9,20 +9,17 @@ use AlexDpy\Acl\Model\Permission;
 use AlexDpy\Acl\Model\PermissionInterface;
 use AlexDpy\Acl\Model\Requester;
 use AlexDpy\Acl\Model\Resource;
+use Doctrine\Common\Cache\ArrayCache;
 
 class PermissionBufferTest extends \PHPUnit_Framework_TestCase
 {
     public function testAdd()
     {
-        $permissionBuffer = $this->getPermissionBuffer();
+        $cacheProvider = $this->prophesize('Doctrine\Common\Cache\CacheProvider');
+        $permissionBuffer = $this->getPermissionBuffer($cacheProvider->reveal());
         $permissionBuffer->add($this->generatePermission('alice', 'foo'));
-        $buffer = $this->getReflectionBufferValue($permissionBuffer);
 
-        $this->assertTrue(($isset = isset($buffer['alicefoo'])));
-
-        if ($isset) {
-            $this->assertInstanceOf('AlexDpy\Acl\Model\PermissionInterface', $buffer['alicefoo']);
-        }
+        $this->assertInstanceOf('AlexDpy\Acl\Model\PermissionInterface', $permissionBuffer->get(new Requester('alice'), new Resource('foo')));
     }
 
     public function testRemove()
@@ -104,8 +101,8 @@ class PermissionBufferTest extends \PHPUnit_Framework_TestCase
     /**
      * @return PermissionBufferInterface
      */
-    private function getPermissionBuffer()
+    private function getPermissionBuffer($cacheProvider = null)
     {
-        return new PermissionBuffer();
+        return new PermissionBuffer($cacheProvider);
     }
 }


### PR DESCRIPTION
- Use null pattern provided by doctrine cache (avoid to check each time if service is available)
- Remove proxy deps since CacheProvider is not a dependency of ACL service but PermissionBuffer

TU are in progress, and BC is introduce since PermissionBuffer is turn in service and ACL require it at runtime
